### PR TITLE
WIP: testing on scikit-learn kernels

### DIFF
--- a/src/python/STRUMPACKKernel.py.in
+++ b/src/python/STRUMPACKKernel.py.in
@@ -46,6 +46,12 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
             print(X.dtype)
             raise ValueError("precision", X.dtype, "not supported")
 
+        if self.kernel is None:  # Use an RBF kernel as default
+            self.kernel_ = C(1.0, constant_value_bounds="fixed") \
+                * RBF(1.0, length_scale_bounds="fixed")
+        else:
+            self.kernel_ = clone(self.kernel)
+
         if self.approximation is not 'HSS' and \
            self.approximation is not 'HODLR':
             raise ValueError("Approximation type not recognized,"
@@ -58,12 +64,6 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
             print("HSS approximation requires vector input,"
                   "using HODLR instead")
             # raise ValueError("HSS approximation requires vector input")
-
-        if self.kernel is None:  # Use an RBF kernel as default
-            self.kernel_ = C(1.0, constant_value_bounds="fixed") \
-                * RBF(1.0, length_scale_bounds="fixed")
-        else:
-            self.kernel_ = clone(self.kernel)
 
         self._rng = check_random_state(self.random_state)
 
@@ -139,7 +139,7 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
 
         # TODO remove, this is for classification
         # store the classes seen during fit
-        self.classes_ = unique_labels(y)
+        # self.classes_ = unique_labels(y)
 
 
         D = self.kernel_.diag(self.X_train_)


### PR DESCRIPTION
I've made a couple of changes in order to make the GPR module work compatible with scikit-learn kernels. However, it still dies during the `fit` process. This can be reproduced by:
```python
import numpy as np
from sklearn.gaussian_process.kernels import RBF
from STRUMPACKKernel import STRUMPACKGaussianProcessRegressor
gpr = STRUMPACKGaussianProcessRegressor(
    kernel=RBF(1.0),
    alpha=3.0,
    copy_X_train=False,
    optimizer=None,
)
gpr.fit(np.random.rand(100, 2), np.random.rand(100))
```