### PR TITLE
Recent tweaks and fixes for GPR on both vector and structured data

### DIFF
--- a/src/python/STRUMPACKKernel.py.in
+++ b/src/python/STRUMPACKKernel.py.in
@@ -1,10 +1,12 @@
+import warnings
 import numpy as np
 import ctypes
 #from sklearn.base import BaseEstimator, ClassifierMixin
 from sklearn.base import BaseEstimator, RegressorMixin, clone
 from sklearn.base import MultiOutputMixin
 from sklearn.utils import check_random_state
-from sklearn.utils.validation import check_X_y, check_array, check_is_fitted
+from sklearn.utils.validation import check_X_y, check_array, check_is_fitted, \
+    _num_samples
 
 # TODO remove this is for classification
 from sklearn.utils.multiclass import unique_labels
@@ -15,15 +17,27 @@ sp = ctypes.cdll.LoadLibrary(
     '@CMAKE_INSTALL_PREFIX@/lib/libstrumpack.so')
 
 
-#class STRUMPACKKernel(BaseEstimator, ClassifierMixin):
+# class STRUMPACKKernel(BaseEstimator, ClassifierMixin):
 class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
+    """Gaussian Process Regressor with STRUMPACK backend
 
-    def __init__(self, kernel=None, alpha=1e-10,
+    Parameters
+    ----------
+    kernel: :py:class`sklearn.gaussian_process.kernels.Kernel` instance
+        A positive definite kernel between feature vectors.
+    alpha: float >= 0
+        Regularization parameter
+    dtype: np.float32 or np.float64
+        Data type to be used for storing the kernel matrix
+    """
+
+    def __init__(self, kernel=None, alpha=1e-10, dtype=np.float64,
                  approximation='HSS', mpi=False, argv=None,
                  optimizer="fmin_l_bfgs_b", n_restarts_optimizer=0,
                  normalize_y=False, copy_X_train=True, random_state=None):
         self.kernel = kernel
         self.alpha = alpha
+        self.dtype = dtype
         self.optimizer = optimizer
         self.n_restarts_optimizer = n_restarts_optimizer
         self.normalize_y = normalize_y
@@ -34,6 +48,8 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
         self.mpi = mpi
         self.argv = argv
 
+        if dtype != np.float32 and dtype != np.float64:
+            raise ValueError("data type", dtype, "not supported")
 
     def __del__(self):
         try: sp.STRUMPACK_destroy_kernel_double(
@@ -42,25 +58,20 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
 
 
     def fit(self, X, y):
-        if X.dtype != np.float32 and \
-           X.dtype != np.float64:
-            print(X.dtype)
-            raise ValueError("precision", X.dtype, "not supported")
-
         if self.kernel is None:  # Use an RBF kernel as default
             self.kernel_ = C(1.0, constant_value_bounds="fixed") \
                 * RBF(1.0, length_scale_bounds="fixed")
         else:
             self.kernel_ = clone(self.kernel)
 
-        if self.approximation is not 'HSS' and \
-           self.approximation is not 'HODLR':
+        if self.approximation != 'HSS' and \
+           self.approximation != 'HODLR':
             raise ValueError("Approximation type not recognized,"
                              "should be 'HSS' or 'HODLR'")
-        if self.approximation is 'HODLR' and self.mpi is False:
+        if self.approximation == 'HODLR' and self.mpi is False:
             raise ValueError("HODLR approximation requires mpi=True")
-        if self.approximation is 'HSS' and \
-           self.kernel_.requires_vector_input is False:
+        if self.approximation == 'HSS' and \
+           self.kernel.requires_vector_input is False:
             self.approximation = 'HODLR'
             print("HSS approximation requires vector input,"
                   "using HODLR instead")
@@ -68,7 +79,7 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
 
         self._rng = check_random_state(self.random_state)
 
-        ## TODO what are those extra options to check_X_y???
+        # TODO what are those extra options to check_X_y???
         if self.kernel_.requires_vector_input:
             X, y = check_X_y(X, y, multi_output=True, y_numeric=True,
                              ensure_2d=True, dtype="numeric")
@@ -121,7 +132,7 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
                         "Multiple optimizer restarts (n_restarts_optimizer>0) "
                         "requires that all bounds are finite.")
                 bounds = self.kernel_.bounds
-                for iteration in range(self.n_restarts_optimizer):
+                for _ in range(self.n_restarts_optimizer):
                     theta_initial = \
                         self._rng.uniform(bounds[:, 0], bounds[:, 1])
                     optima.append(
@@ -137,72 +148,62 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
                 self.log_marginal_likelihood(self.kernel_.theta,
                                              clone_kernel=False)
 
-
         # TODO remove, this is for classification
         # store the classes seen during fit
         # self.classes_ = unique_labels(y)
-
 
         D = self.kernel_.diag(self.X_train_)
 
         # callback function for STRUMPACK kernel evaluation
         def Kx_block(m, I, n, J, B, ldB, f):
             Ksub = self.kernel_(
-                self.X_train_[[I[i] for i in range(m)],:],
-                self.X_train_[[J[j] for j in range(n)],:])
+                self.X_train_[[I[i] for i in range(m)], :],
+                self.X_train_[[J[j] for j in range(n)], :])
             for j in range(n):
                 for i in range(m):
-                    B[i+j*ldB] = Ksub[i,j]
+                    B[i+j*ldB] = Ksub[i, j]
 
-        ELEMBLOCKFUNCf64 = ctypes.CFUNCTYPE(None,
+        ELEMBLOCKFUNCf64 = ctypes.CFUNCTYPE(
+            None,
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.POINTER(ctypes.c_double), ctypes.c_size_t,
             ctypes.c_int)
-        ELEMBLOCKFUNCf32 = ctypes.CFUNCTYPE(None,
+        ELEMBLOCKFUNCf32 = ctypes.CFUNCTYPE(
+            None,
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.POINTER(ctypes.c_float), ctypes.c_size_t,
             ctypes.c_int)
         Kx_block_fptr_f64 = ELEMBLOCKFUNCf64(Kx_block)
         Kx_block_fptr_f32 = ELEMBLOCKFUNCf32(Kx_block)
-        if X.dtype == np.float64:
+
+        if self.kernel_.requires_vector_input:
+            d = ctypes.c_int(X.shape[1])
+        else:
+            d = ctypes.c_int(0)
+
+        if self.dtype == np.float64:
             sp.STRUMPACK_create_general_kernel_double.restype = ctypes.c_void_p
-            if self.kernel_.requires_vector_input:
-                self.K_ = sp.STRUMPACK_create_general_kernel_double(
-                    ctypes.c_int(self.X_train_.shape[0]),
-                    ctypes.c_int(self.X_train_.shape[1]),
-                    ctypes.c_void_p(self.X_train_.ctypes.data),
-                    Kx_block_fptr_f64, ctypes.c_void_p(None),
-                    ctypes.c_double(self.alpha))
-            else:
-                self.K_ = sp.STRUMPACK_create_general_kernel_double(
-                    ctypes.c_int(self.X_train_.shape[0]), ctypes.c_int(0),
-                    ctypes.c_void_p(None), Kx_block_fptr_f64,
-                    ctypes.c_void_p(None), ctypes.c_double(self.alpha))
-            sp.STRUMPACK_kernel_set_diagonal_double(
-                ctypes.c_void_p(self.K_),
-                ctypes.c_void_p(D.ctypes.data));
-
-        elif X.dtype == np.float32:
+            self.K_ = sp.STRUMPACK_create_general_kernel_double(
+                ctypes.c_int(_num_samples(X)),
+                d,
+                ctypes.c_void_p(self.X_train_.ctypes.data),
+                Kx_block_fptr_f64,
+                ctypes.c_void_p(None),
+                ctypes.c_double(self.alpha))
+        elif self.dtype == np.float32:
             sp.STRUMPACK_create_general_kernel_float.restype = ctypes.c_void_p
-            if self.kernel_.requires_vector_input:
-                self.K_ = sp.STRUMPACK_create_general_kernel_float(
-                    ctypes.c_int(self.X_train_.shape[0]),
-                    ctypes.c_int(self.X_train_.shape[1]),
-                    ctypes.c_void_p(self.X_train_.ctypes.data),
-                    Kx_block_fptr_f32, ctypes.c_void_p(None),
-                    ctypes.c_float(self.alpha))
-            else:
-                self.K_ = sp.STRUMPACK_create_general_kernel_float(
-                    ctypes.c_int(X.shape[0]), ctypes.c_int(X.shape[1]),
-                    ctypes.c_void_p(None), Kx_block_fptr_f32,
-                    ctypes.c_void_p(None), ctypes.c_float(self.alpha))
-            sp.STRUMPACK_kernel_set_diagonal_float(
-                ctypes.c_void_p(self.K_),
-                ctypes.c_void_p(D.ctypes.data));
+            self.K_ = sp.STRUMPACK_create_general_kernel_float(
+                ctypes.c_int(_num_samples(X)),
+                d,
+                ctypes.c_void_p(self.X_train_.ctypes.data),
+                Kx_block_fptr_f32,
+                ctypes.c_void_p(None),
+                ctypes.c_float(self.alpha))
 
-        if self.argv is None: self.argv=[]
+        if self.argv is None:
+            self.argv = []
         LP_c_char = ctypes.POINTER(ctypes.c_char)
         argc = len(self.argv)
         argv = (LP_c_char * (argc + 1))()
@@ -210,43 +211,42 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
             enc_arg = arg.encode('utf-8')
             argv[i] = ctypes.create_string_buffer(enc_arg)
 
-        if self.approximation is 'HSS':
+        if self.approximation == 'HSS':
             if self.mpi:
-                if X.dtype == np.float64:
+                if self.dtype == np.float64:
                     sp.STRUMPACK_kernel_fit_HSS_MPI_double(
                         ctypes.c_void_p(self.K_),
                         ctypes.c_void_p(y.ctypes.data),
                         ctypes.c_int(argc), argv)
-                elif X.dtype == np.float32:
+                elif self.dtype == np.float32:
                     sp.STRUMPACK_kernel_fit_HSS_MPI_float(
                         ctypes.c_void_p(self.K_),
                         ctypes.c_void_p(y.ctypes.data),
                         ctypes.c_int(argc), argv)
             else:
-                if X.dtype == np.float64:
+                if self.dtype == np.float64:
                     sp.STRUMPACK_kernel_fit_HSS_double(
                         ctypes.c_void_p(self.K_),
                         ctypes.c_void_p(y.ctypes.data),
                         ctypes.c_int(argc), argv)
-                elif X.dtype == np.float32:
+                elif self.dtype == np.float32:
                     sp.STRUMPACK_kernel_fit_HSS_float(
                         ctypes.c_void_p(self.K_),
                         ctypes.c_void_p(y.ctypes.data),
                         ctypes.c_int(argc), argv)
-        elif self.approximation is 'HODLR':
-            if X.dtype == np.float64:
+        elif self.approximation == 'HODLR':
+            if self.dtype == np.float64:
                 sp.STRUMPACK_kernel_fit_HODLR_MPI_double(
                     ctypes.c_void_p(self.K_),
                     ctypes.c_void_p(y.ctypes.data),
                     ctypes.c_int(argc), argv)
-            elif X.dtype == np.float32:
+            elif self.dtype == np.float32:
                 sp.STRUMPACK_kernel_fit_HODLR_MPI_float(
                     ctypes.c_void_p(self.K_),
                     ctypes.c_void_p(y.ctypes.data),
                     ctypes.c_int(argc), argv)
         # return the classifier
         return self
-
 
     def predict(self, X, return_std=False, return_cov=False):
         if return_std and return_cov:
@@ -265,7 +265,7 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
                           RBF(1.0, length_scale_bounds="fixed"))
             else:
                 kernel = self.kernel
-            y_mean = np.zeros(X.shape[0])
+            y_mean = np.zeros(X.shape[0], dtype=self.dtype)
             if return_cov:
                 y_cov = kernel(X)
                 return y_mean, y_cov
@@ -277,15 +277,16 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
         else:  # Predict based on GP posterior
             # K_trans = self.kernel_(X, self.X_train_)
             # y_mean = K_trans.dot(self.alpha_)  # Line 4 (y_mean = f_star)
-            y_mean = np.zeros((X.shape[0],1), dtype=X.dtype)
+            y_mean = np.zeros((X.shape[0], 1), dtype=X.dtype)
+
             # callback function for STRUMPACK kernel evaluation
             def Kxy_block(m, I, n, J, B, ldB, f):
                 Ksub = self.kernel_(
-                    self.X_train_[[I[i] for i in range(m)],:],
-                    X[[J[j] for j in range(n)],:])
+                    self.X_train_[[I[i] for i in range(m)]],
+                    X[[J[j] for j in range(n)]])
                 for j in range(n):
                     for i in range(m):
-                        B[i+j*ldB] = Ksub[i,j]
+                        B[i+j*ldB] = Ksub[i, j]
 
             ELEMBLOCKFUNCf64 = ctypes.CFUNCTYPE(
                 None,
@@ -301,16 +302,16 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
                 ctypes.c_int)
             Kxy_block_fptr_f64 = ELEMBLOCKFUNCf64(Kxy_block)
             Kxy_block_fptr_f32 = ELEMBLOCKFUNCf32(Kxy_block)
-            if X.dtype == np.float64:
+            if self.dtype == np.float64:
                 sp.STRUMPACK_general_kernel_predict_double(
                     ctypes.c_void_p(self.K_),
-                    ctypes.c_int(X.shape[0]),
+                    ctypes.c_int(_num_samples(X)),
                     Kxy_block_fptr_f64, ctypes.c_void_p(None),
                     ctypes.c_void_p(y_mean.ctypes.data))
-            elif X.dtype == np.float32:
+            elif self.dtype == np.float32:
                 sp.STRUMPACK_general_kernel_predict_float(
                     ctypes.c_void_p(self.K_),
-                    ctypes.c_int(X.shape[0]),
+                    ctypes.c_int(_num_samples(X)),
                     Kxy_block_fptr_f32, ctypes.c_void_p(None),
                     ctypes.c_void_p(y_mean.ctypes.data))
 
@@ -347,23 +348,25 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
     def predict_classify(self, X):
         # TODO make sure there are only 2 classes?
         check_is_fitted(self, 'K_')
-        prediction = np.zeros((X.shape[0],1), dtype=X.dtype)
+        prediction = np.zeros((X.shape[0], 1), dtype=X.dtype)
 
         # callback function for STRUMPACK kernel evaluation
         def Kxy_block(m, I, n, J, B, ldB, f):
             Ksub = self.kernel_(
-                self.X_train_[[I[i] for i in range(m)],:],
-                X[[J[j] for j in range(n)],:])
+                self.X_train_[[I[i] for i in range(m)], :],
+                X[[J[j] for j in range(n)], :])
             for j in range(n):
                 for i in range(m):
-                    B[i+j*ldB] = Ksub[i,j]
+                    B[i+j*ldB] = Ksub[i, j]
 
-        ELEMBLOCKFUNCf64 = ctypes.CFUNCTYPE(None,
+        ELEMBLOCKFUNCf64 = ctypes.CFUNCTYPE(
+            None,
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.POINTER(ctypes.c_double), ctypes.c_size_t,
             ctypes.c_int)
-        ELEMBLOCKFUNCf32 = ctypes.CFUNCTYPE(None,
+        ELEMBLOCKFUNCf32 = ctypes.CFUNCTYPE(
+            None,
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.c_size_t, ctypes.POINTER(ctypes.c_size_t),
             ctypes.POINTER(ctypes.c_float), ctypes.c_size_t,

--- a/src/python/STRUMPACKKernel.py.in
+++ b/src/python/STRUMPACKKernel.py.in
@@ -157,8 +157,8 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
         # callback function for STRUMPACK kernel evaluation
         def Kx_block(m, I, n, J, B, ldB, f):
             Ksub = self.kernel_(
-                self.X_train_[[I[i] for i in range(m)], :],
-                self.X_train_[[J[j] for j in range(n)], :])
+                self.X_train_[[I[i] for i in range(m)]],
+                self.X_train_[[J[j] for j in range(n)]])
             for j in range(n):
                 for i in range(m):
                     B[i+j*ldB] = Ksub[i, j]
@@ -183,12 +183,17 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
         else:
             d = ctypes.c_int(0)
 
+        if self.kernel_.requires_vector_input:
+            p_data = ctypes.c_void_p(self.X_train_.ctypes.data)
+        else:
+            p_data = ctypes.c_void_p(None)
+
         if self.dtype == np.float64:
             sp.STRUMPACK_create_general_kernel_double.restype = ctypes.c_void_p
             self.K_ = sp.STRUMPACK_create_general_kernel_double(
                 ctypes.c_int(_num_samples(X)),
                 d,
-                ctypes.c_void_p(self.X_train_.ctypes.data),
+                p_data,
                 Kx_block_fptr_f64,
                 ctypes.c_void_p(None),
                 ctypes.c_double(self.alpha))
@@ -197,7 +202,7 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
             self.K_ = sp.STRUMPACK_create_general_kernel_float(
                 ctypes.c_int(_num_samples(X)),
                 d,
-                ctypes.c_void_p(self.X_train_.ctypes.data),
+                p_data,
                 Kx_block_fptr_f32,
                 ctypes.c_void_p(None),
                 ctypes.c_float(self.alpha))
@@ -277,7 +282,7 @@ class STRUMPACKGaussianProcessRegressor(GaussianProcessRegressor):
         else:  # Predict based on GP posterior
             # K_trans = self.kernel_(X, self.X_train_)
             # y_mean = K_trans.dot(self.alpha_)  # Line 4 (y_mean = f_star)
-            y_mean = np.zeros((X.shape[0], 1), dtype=X.dtype)
+            y_mean = np.zeros(_num_samples(X), dtype=self.dtype)
 
             # callback function for STRUMPACK kernel evaluation
             def Kxy_block(m, I, n, J, B, ldB, f):


### PR DESCRIPTION
This is a short summary of the changes that we made together this afternoon:
- Use the `_num_samples` helper from scikit-learn to compute dataset size.
- Made the matrix `dtype` part of the arguments to the regressor and defaults to `np.float64`.
- list indexing works for both generic object arrays and 2D ndarrays.
- refactored matrix creation logic to account for both generic and vector data.
- misc Python styling tweaks.