### PR TITLE
Fixes for mixed precision solvers

### DIFF
--- a/src/SparseSolverMixedPrecision.cpp
+++ b/src/SparseSolverMixedPrecision.cpp
@@ -188,8 +188,28 @@ namespace strumpack {
     solver_.set_matrix(A);
   }
 
+  template<typename factor_t,typename refine_t,typename integer_t> void
+  SparseSolverMixedPrecision<factor_t,refine_t,integer_t>::
+  update_matrix_values(const CSRMatrix<refine_t,integer_t>& A) {
+    mat_ = A;
+    solver_.update_matrix_values(cast_matrix<refine_t,integer_t,factor_t>(A));
+  }
+
+  template<typename factor_t,typename refine_t,typename integer_t> void
+  SparseSolverMixedPrecision<factor_t,refine_t,integer_t>::
+  update_matrix_values(const CSRMatrix<factor_t,integer_t>& A) {
+    mat_ = cast_matrix<factor_t,integer_t,refine_t>(A);
+    solver_.update_matrix_values(A);
+  }
+
   // explicit template instantiations
   template class SparseSolverMixedPrecision<float,double,int>;
   template class SparseSolverMixedPrecision<std::complex<float>,std::complex<double>,int>;
+
+  template class SparseSolverMixedPrecision<float,double,long int>;
+  template class SparseSolverMixedPrecision<std::complex<float>,std::complex<double>,long int>;
+
+  template class SparseSolverMixedPrecision<float,double,long long int>;
+  template class SparseSolverMixedPrecision<std::complex<float>,std::complex<double>,long long int>;
 
 } //end namespace strumpack

--- a/src/SparseSolverMixedPrecisionMPIDist.cpp
+++ b/src/SparseSolverMixedPrecisionMPIDist.cpp
@@ -160,8 +160,21 @@ namespace strumpack {
     solver_.set_matrix(cast_matrix<refine_t,integer_t,factor_t>(A));
   }
 
+  template<typename factor_t,typename refine_t,typename integer_t> void
+  SparseSolverMixedPrecisionMPIDist<factor_t,refine_t,integer_t>::
+  update_matrix_values(const CSRMatrixMPI<refine_t,integer_t>& A) {
+    mat_ = A;
+    solver_.update_matrix_values(cast_matrix<refine_t,integer_t,factor_t>(A));
+  }
+
   // explicit template instantiations
   template class SparseSolverMixedPrecisionMPIDist<float,double,int>;
   template class SparseSolverMixedPrecisionMPIDist<std::complex<float>,std::complex<double>,int>;
+
+  template class SparseSolverMixedPrecisionMPIDist<float,double,long int>;
+  template class SparseSolverMixedPrecisionMPIDist<std::complex<float>,std::complex<double>,long int>;
+
+  template class SparseSolverMixedPrecisionMPIDist<float,double,long long int>;
+  template class SparseSolverMixedPrecisionMPIDist<std::complex<float>,std::complex<double>,long long int>;
 
 } //end namespace strumpack

--- a/src/StrumpackSparseSolverMixedPrecision.hpp
+++ b/src/StrumpackSparseSolverMixedPrecision.hpp
@@ -111,6 +111,9 @@ namespace strumpack {
     void set_matrix(const CSRMatrix<refine_t,integer_t>& A);
     void set_matrix(const CSRMatrix<factor_t,integer_t>& A);
 
+    void update_matrix_values(const CSRMatrix<refine_t,integer_t>& A);
+    void update_matrix_values(const CSRMatrix<factor_t,integer_t>& A);
+
     ReturnCode factor();
     ReturnCode reorder(int nx=1, int ny=1, int nz=1);
 

--- a/src/StrumpackSparseSolverMixedPrecisionMPIDist.hpp
+++ b/src/StrumpackSparseSolverMixedPrecisionMPIDist.hpp
@@ -110,8 +110,11 @@ namespace strumpack {
 
     void set_matrix(const CSRMatrixMPI<refine_t,integer_t>& A);
 
+    void update_matrix_values(const CSRMatrixMPI<refine_t,integer_t>& A);
+
     ReturnCode factor();
     ReturnCode reorder(int nx=1, int ny=1, int nz=1);
+
     ReturnCode solve(const DenseMatrix<refine_t>& b,
                      DenseMatrix<refine_t>& x,
                      bool use_initial_guess=false);

--- a/src/sparse/CSRMatrix.cpp
+++ b/src/sparse/CSRMatrix.cpp
@@ -1239,6 +1239,13 @@ namespace strumpack {
   //   return g;
   // }
 
+  template<typename scalar_t, typename integer_t, typename cast_t>
+  CSRMatrix<cast_t,integer_t>
+  cast_matrix(const CSRMatrix<scalar_t,integer_t>& mat) {
+    std::vector<cast_t> new_val(mat.val(), mat.val()+mat.nnz());
+    return CSRMatrix<cast_t,integer_t>
+      (mat.size(), mat.ptr(), mat.ind(), new_val.data(), mat.symm_sparse());
+  }
 
   // explicit template instantiations
   template class CSRMatrix<float,int>;
@@ -1256,17 +1263,6 @@ namespace strumpack {
   template class CSRMatrix<std::complex<float>,long long int>;
   template class CSRMatrix<std::complex<double>,long long int>;
 
-
-
-  template<typename scalar_t, typename integer_t, typename cast_t>
-  CSRMatrix<cast_t,integer_t>
-  cast_matrix(const CSRMatrix<scalar_t,integer_t>& mat) {
-    std::vector<cast_t> new_val(mat.val(), mat.val()+mat.nnz());
-    return CSRMatrix<cast_t,integer_t>
-      (mat.size(), mat.ptr(), mat.ind(), new_val.data(), mat.symm_sparse());
-  }
-
-  // explicit template instantiations
   template CSRMatrix<float,int>
   cast_matrix<double,int,float>(const CSRMatrix<double,int>& mat);
   template CSRMatrix<double,int>

--- a/src/sparse/CSRMatrixMPI.cpp
+++ b/src/sparse/CSRMatrixMPI.cpp
@@ -1031,6 +1031,14 @@ namespace strumpack {
     return comm_.all_reduce(m, MPI_MAX);
   }
 
+  template<typename scalar_t, typename integer_t, typename cast_t>
+  CSRMatrixMPI<cast_t,integer_t>
+  cast_matrix(const CSRMatrixMPI<scalar_t,integer_t>& mat) {
+    std::vector<cast_t> new_val(mat.val(), mat.val()+mat.local_nnz());
+    return CSRMatrixMPI<cast_t,integer_t>
+      (mat.local_rows(), mat.ptr(), mat.ind(), new_val.data(),
+       mat.dist().data(), mat.Comm(), mat.symm_sparse());
+  }
 
   // explicit template instantiations
   template class CSRMatrixMPI<float,int>;
@@ -1048,20 +1056,31 @@ namespace strumpack {
   template class CSRMatrixMPI<std::complex<float>,long long int>;
   template class CSRMatrixMPI<std::complex<double>,long long int>;
 
-
-  template<typename scalar_t, typename integer_t, typename cast_t>
-  CSRMatrixMPI<cast_t,integer_t>
-  cast_matrix(const CSRMatrixMPI<scalar_t,integer_t>& mat) {
-    std::vector<cast_t> new_val(mat.val(), mat.val()+mat.local_nnz());
-    return CSRMatrixMPI<cast_t,integer_t>
-      (mat.local_rows(), mat.ptr(), mat.ind(), new_val.data(),
-       mat.dist().data(), mat.Comm(), mat.symm_sparse());
-  }
-
   template CSRMatrixMPI<float,int>
   cast_matrix<double,int,float>(const CSRMatrixMPI<double,int>& mat);
+  template CSRMatrixMPI<double,int>
+  cast_matrix<float,int,double>(const CSRMatrixMPI<float,int>& mat);
   template CSRMatrixMPI<std::complex<float>,int>
-  cast_matrix<std::complex<double>,int,std::complex<float>>
-  (const CSRMatrixMPI<std::complex<double>,int>& mat);
+  cast_matrix<std::complex<double>,int,std::complex<float>>(const CSRMatrixMPI<std::complex<double>,int>& mat);
+  template CSRMatrixMPI<std::complex<double>,int>
+  cast_matrix<std::complex<float>,int,std::complex<double>>(const CSRMatrixMPI<std::complex<float>,int>& mat);
+
+  template CSRMatrixMPI<float,long int>
+  cast_matrix<double,long int,float>(const CSRMatrixMPI<double,long int>& mat);
+  template CSRMatrixMPI<double,long int>
+  cast_matrix<float,long int,double>(const CSRMatrixMPI<float,long int>& mat);
+  template CSRMatrixMPI<std::complex<float>,long int>
+  cast_matrix<std::complex<double>,long int,std::complex<float>>(const CSRMatrixMPI<std::complex<double>,long int>& mat);
+  template CSRMatrixMPI<std::complex<double>,long int>
+  cast_matrix<std::complex<float>,long int,std::complex<double>>(const CSRMatrixMPI<std::complex<float>,long int>& mat);
+
+  template CSRMatrixMPI<float,long long int>
+  cast_matrix<double,long long int,float>(const CSRMatrixMPI<double,long long int>& mat);
+  template CSRMatrixMPI<double,long long int>
+  cast_matrix<float,long long int,double>(const CSRMatrixMPI<float,long long int>& mat);
+  template CSRMatrixMPI<std::complex<float>,long long int>
+  cast_matrix<std::complex<double>,long long int,std::complex<float>>(const CSRMatrixMPI<std::complex<double>,long long int>& mat);
+  template CSRMatrixMPI<std::complex<double>,long long int>
+  cast_matrix<std::complex<float>,long long int,std::complex<double>>(const CSRMatrixMPI<std::complex<float>,long long int>& mat);
 
 } // end namespace strumpack


### PR DESCRIPTION
Adds explicit template instantiations for `long int` and `long long int`, and add `update_matrix_values` methods.