### PR TITLE
Set SOVERSION and VERSION properties for building shared library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -541,7 +541,10 @@ endif()
 
 # this is to fix a link issue for the fortran example when compiling
 # with clang
-set_property(TARGET strumpack PROPERTY POSITION_INDEPENDENT_CODE ON)
+set_target_properties(strumpack PROPERTIES
+  VERSION "${PROJECT_VERSION}"
+  SOVERSION "${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}"
+  POSITION_INDEPENDENT_CODE ON)
 
 
 # see https://github.com/pghysels/STRUMPACK/issues/82


### PR DESCRIPTION
Adding a SOVERSION to the shared library can help indicating API/ABI changes of this library.

Ref: https://tldp.org/HOWTO/Program-Library-HOWTO/shared-libraries.html
https://en.wikipedia.org/wiki/Soname
https://docs.fedoraproject.org/en-US/packaging-guidelines/#_downstream_so_name_versioning