### PR TITLE
Add HSSMatrix.sketch.hpp to install in src/HSS/CMakeLists.txt

### DIFF
--- a/src/HSS/CMakeLists.txt
+++ b/src/HSS/CMakeLists.txt
@@ -24,6 +24,7 @@ install(FILES
   HSSExtra.hpp
   HSSMatrixBase.hpp
   HSSOptions.hpp
+  HSSMatrix.sketch.hpp
   DESTINATION include/HSS)
 
 


### PR DESCRIPTION
HSSMatrix.hpp includes HSSMatrix.sketch.hpp, but the latter wasn't getting installed.  Added it to the install section of the relevent CMakeLists.txt file so it would be installed.