### PR TITLE
Replace &foo[n] with foo.data() + n

### DIFF
--- a/src/sparse/CSRGraph.cpp
+++ b/src/sparse/CSRGraph.cpp
@@ -74,7 +74,7 @@ namespace strumpack {
     auto n = size();
 #pragma omp parallel for
     for (integer_t r=0; r<n; r++)
-      std::sort(&ind_[ptr_[r]], &ind_[ptr_[r+1]]);
+       std::sort(ind_.data()+ptr_[r], ind_.data()+ptr_[r + 1]);
   }
 
   template<typename integer_t> void

--- a/src/sparse/CSRMatrixMPI.cpp
+++ b/src/sparse/CSRMatrixMPI.cpp
@@ -465,10 +465,10 @@ namespace strumpack {
       // like std::partition but on ind and val arrays simultaneously
       auto lo = ptr_[row];
       auto hi = ptr_[row+1];
-      auto first_ind = &ind_[lo];
-      auto last_ind = &ind_[hi];
-      auto first_val = &val_[lo];
-      auto last_val = &val_[hi];
+      auto first_ind = ind_.data() + lo;
+      auto last_ind = ind_.data() + hi;
+      auto first_val = val_.data() + lo;
+      auto last_val = val_.data() + hi;
       while (1) {
         while ((first_ind != last_ind) && is_diag(*first_ind)) {
           ++first_ind; ++first_val;


### PR DESCRIPTION
Fixes some out of bounds issues when running under Windows with std::vector bounds checking.