### PR TITLE
Remove rocthrust from strumpack target

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,7 +150,6 @@ if(STRUMPACK_USE_HIP)
     find_package(rocsolver REQUIRED)
     find_package(rocblas REQUIRED)
     find_package(rocprim REQUIRED)
-    find_package(rocthrust REQUIRED)
   endif()
 endif()
 
@@ -701,7 +700,7 @@ endif()
 
 if(hipblas_FOUND)
   target_link_libraries(strumpack PUBLIC
-    roc::hipblas roc::rocblas roc::rocsolver roc::hipsparse roc::rocthrust)
+    roc::hipblas roc::rocblas roc::rocsolver roc::hipsparse)
 endif()
 
 if(CombBLAS_FOUND)


### PR DESCRIPTION
The CMake target `hip::device` is contaminating all source files with the `-x hip` compile option, which is being imported via the chain of `roc::rocthrust` → `rocprim` → `hip::device`:
```
grep -R -- "-x hip" /opt/rocm/lib/cmake /opt/rocm/include 2>/dev/null
/opt/rocm/lib/cmake/hip/hip-config-amd.cmake:  hip_add_interface_compile_flags(hip::device -x hip)
```

Because of this, when the host compiler is not clang, you get:
```
g++: error: language hip not recognized
```

Since thrust is a header-only library, it doesn't need to be specified.

This is observed with ROCm 7.2.4.